### PR TITLE
Update URL in swapi.yaml

### DIFF
--- a/example/swapi.yaml
+++ b/example/swapi.yaml
@@ -3,7 +3,7 @@ info:
   version: 1.0.0
   title: The Star Wars API
 servers:
-  - url: https://swapi.co/api/
+  - url: https://swapi.dev/api/
 paths:
   /planets:
     get:


### PR DESCRIPTION
The original app at https://swapi.co is gone.
A successor project is https://swapi.dev.
This PR solves issue #1.